### PR TITLE
Quit inner glib loop when needed

### DIFF
--- a/asyncio_glib/glib_events.py
+++ b/asyncio_glib/glib_events.py
@@ -15,10 +15,10 @@ __all__ = (
 class GLibEventLoop(asyncio.SelectorEventLoop):
     """An asyncio event loop that runs the GLib main loop"""
 
-    def __init__(self, main_context=None):
+    def __init__(self, main_context=None, handle_sigint=False):
         if main_context is None:
             main_context = GLib.MainContext.default()
-        selector = glib_selector.GLibSelector(main_context)
+        selector = glib_selector.GLibSelector(main_context, handle_sigint)
         self.selector = selector
         super().__init__(selector)
 

--- a/asyncio_glib/glib_events.py
+++ b/asyncio_glib/glib_events.py
@@ -19,7 +19,29 @@ class GLibEventLoop(asyncio.SelectorEventLoop):
         if main_context is None:
             main_context = GLib.MainContext.default()
         selector = glib_selector.GLibSelector(main_context)
+        self.selector = selector
         super().__init__(selector)
+
+    def call_at(self, *args, **kwargs):
+        self._write_to_self()
+        return super().call_at(*args, **kwargs)
+
+    def call_later(self, *args, **kwargs):
+        self._write_to_self()
+        return super().call_later(*args, **kwargs)
+
+    def call_soon(self, *args, **kwargs):
+        self._write_to_self()
+        return super().call_soon(*args, **kwargs)
+
+    def _add_callback(self, *args, **kwargs):
+        self._write_to_self()
+        return super()._add_callback(*args, **kwargs)
+
+    def _write_to_self(self):
+        # the superclass one would probably do
+        # but this uses glib's eventfd rather than fake IO
+        self.selector.quit()
 
 
 class GLibEventLoopPolicy(asyncio.DefaultEventLoopPolicy):

--- a/asyncio_glib/glib_selector.py
+++ b/asyncio_glib/glib_selector.py
@@ -67,10 +67,15 @@ class _SelectorSource(GLib.Source):
 
 class GLibSelector(selectors._BaseSelectorImpl):
 
-    def __init__(self, context):
+    def __init__(self, context, handle_sigint=False):
         super().__init__()
         self._context = context
-        self._main_loop = GLib.MainLoop.new(self._context, False)
+        if handle_sigint:
+            self._main_loop = GLib.MainLoop()
+            self._run = GLib.MainLoop.run
+        else:
+            self._main_loop = GLib.MainLoop.new(self._context, False)
+            self._run = g_main_loop_run
         self._source = _SelectorSource(self._main_loop)
         self._source.attach(self._context)
 
@@ -100,7 +105,7 @@ class GLibSelector(selectors._BaseSelectorImpl):
 
         self._source.clear()
         if may_block:
-            g_main_loop_run(self._main_loop)
+            self._run(self._main_loop)
         else:
             self._context.iteration(False)
 

--- a/asyncio_glib/glib_selector.py
+++ b/asyncio_glib/glib_selector.py
@@ -110,3 +110,6 @@ class GLibSelector(selectors._BaseSelectorImpl):
             if events != 0:
                 ready.append((key, events))
         return ready
+
+    def quit(self):
+        self._main_loop.quit()


### PR DESCRIPTION
... such as when a python asyncio callback is scheduled (this is a variation on other pull requests).

Also, optionally allow GLib's (override) handling of SIGINT (rather than viewing as interference), so one escape the loop that way as well.