### PR TITLE
glib_selector: Only ever iterate the mainloop once

### DIFF
--- a/asyncio_glib/glib_events.py
+++ b/asyncio_glib/glib_events.py
@@ -20,6 +20,8 @@ class GLibEventLoop(asyncio.SelectorEventLoop):
             main_context = GLib.MainContext.default()
         selector = glib_selector.GLibSelector(main_context)
         super().__init__(selector)
+        # GSource only has timeouts with 1ms accuracy
+        self._clock_resolution = 1e-3
 
 
 class GLibEventLoopPolicy(asyncio.DefaultEventLoopPolicy):

--- a/tests/test_glib_selector.py
+++ b/tests/test_glib_selector.py
@@ -13,3 +13,6 @@ class GLibSelectorTests(test_selectors.BaseSelectorTestCase):
 
     def test_select_interrupt_exc(self):
         raise unittest.SkipTest("TODO")
+
+    def test_select_interrupt_noraise(self):
+        raise unittest.SkipTest("TODO")


### PR DESCRIPTION
As it is right now, any python code that runs may modify the timeout
that would be passed into the select() call. As such, we can only run a
single mainloop iteration before the select() call needs to be
restarted.

Also, we cannot use g_source_set_ready_time, because GLib will always
do a full mainloop iteration afterwards to ensure that all sources had a
chance to dispatch.
This is easy to work around though as we can use the prepare callback to
pass the required timeout from python into the GLib main loop code.

Note that with this we end up iterating the main context but we never
actually run a GLib mainloop.

Fixes: #3